### PR TITLE
Fix for deleting objects: object path must be URL percent-encoded.

### DIFF
--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -50,7 +50,7 @@ defmodule Waffle.Storage.Google.CloudStorage do
     Objects.storage_objects_delete(
       conn(),
       bucket(definition),
-      path_for(definition, version, meta)
+      path_for(definition, version, meta) |> URI.encode_www_form()
     )
   end
 


### PR DESCRIPTION
Requests to delete individual versions were failing but the errors were not bubbling up.

The object path is used in GoogleApi.Storage.V1.Api.Objects.storage_objects_delete/3 to construct the URL to delete the resource and needs to be encoded as documented here:

https://cloud.google.com/storage/docs/json_api/v1/objects/delete