### PR TITLE
Pass file meta as argument to token store

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,24 @@ over token generation, you can define your own module:
 ```elixir
 defmodule MyCredentials do
   @behaviour Waffle.Storage.Google.Token.Fetcher
+
+  alias MyApp.Admin
+  alias MyApp.User
+
   @impl Waffle.Storage.Google.Token.Fetcher
-  def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
-  @impl Waffle.Storage.Google.Token.Fetcher
-  def get_token(scope) when is_binary(scope) do
-    {:ok, token} = Goth.Token.for_scope({"my-user@my-gcs-account.com", scope})
+  def get_token(scope, {_file, %schema{}}) do
+    {:ok, token} =
+      Goth.Token.for_scope({
+        get_account(schema),
+        scope
+      })
+
     token.token
   end
+
+  @spec get_account(module()) :: String.t()
+  defp get_account(Admin), do: "my-admin@my-gcs-account.com"
+  defp get_account(User), do: "my-user@my-gcs-account.com"
 end
 ```
 

--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -79,12 +79,12 @@ defmodule Waffle.Storage.Google.CloudStorage do
   Constructs a new connection object with scoped authentication. If no scope is
   provided, the `devstorage.full_control` scope is used as a default.
   """
-  @spec conn(Types.meta()) :: Tesla.Env.client()
-  def conn(meta) do
+  @spec conn(String.t(), Types.meta() | nil) :: Tesla.Env.client()
+  def conn(scope \\ @full_control_scope, meta \\ nil) do
     token_store =
       Application.get_env(:waffle, :token_fetcher, Waffle.Storage.Google.Token.DefaultFetcher)
 
-    @full_control_scope
+    scope
     |> token_store.get_token(meta)
     |> Connection.new()
   end

--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -44,8 +44,8 @@ defmodule Waffle.Storage.Google.CloudStorage do
       |> get_gcs_optional_params(version, meta)
       |> ensure_keyword_list()
 
-    meta
-    |> conn()
+    @full_control_scope
+    |> conn(meta)
     |> insert(bucket(definition), path, data(meta), gcs_options, gcs_optional_params)
   end
 
@@ -54,8 +54,8 @@ defmodule Waffle.Storage.Google.CloudStorage do
   """
   @spec delete(Types.definition(), Types.version(), Types.meta()) :: object_or_error
   def delete(definition, version, meta) do
-    meta
-    |> conn()
+    @full_control_scope
+    |> conn(meta)
     |> Objects.storage_objects_delete(
       bucket(definition),
       path_for(definition, version, meta)

--- a/lib/waffle/storage/google/token/default_fetcher.ex
+++ b/lib/waffle/storage/google/token/default_fetcher.ex
@@ -2,7 +2,7 @@ defmodule Waffle.Storage.Google.Token.DefaultFetcher do
   @behaviour Waffle.Storage.Google.Token.Fetcher
 
   @impl Waffle.Storage.Google.Token.Fetcher
-  def get_token(scope) do
+  def get_token(scope, _meta) do
     {:ok, token} = Goth.Token.for_scope(scope)
     token.token
   end

--- a/lib/waffle/storage/google/token/fetcher.ex
+++ b/lib/waffle/storage/google/token/fetcher.ex
@@ -1,3 +1,3 @@
 defmodule Waffle.Storage.Google.Token.Fetcher do
-  @callback get_token(binary) :: binary
+  @callback get_token(binary(), Waffle.Types.meta()) :: binary()
 end

--- a/lib/waffle/storage/google/token/fetcher.ex
+++ b/lib/waffle/storage/google/token/fetcher.ex
@@ -1,3 +1,3 @@
 defmodule Waffle.Storage.Google.Token.Fetcher do
-  @callback get_token(binary(), Waffle.Types.meta()) :: binary()
+  @callback get_token(binary(), Waffle.Types.meta() | nil) :: binary()
 end


### PR DESCRIPTION
Passes `Waffle.Types.meta()` as argument to `CloudStorage.conn/2` and `token_store.get_token/2`.

This way we can have different service accounts for different metas/schemas, i.e. sensitive vs public files.